### PR TITLE
Make GridKit compatible with Sundials 6.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if(GRIDKIT_ENABLE_IPOPT)
   include(FindIpopt)
 endif()
 if(GRIDKIT_ENABLE_SUNDIALS)
-  find_package(SUNDIALS 5.5.0 REQUIRED CONFIG 
+  find_package(SUNDIALS 6.0.0 REQUIRED CONFIG 
                PATHS ${SUNDIALS_DIR}
                      ${SUNDIALS_DIR}/lib/cmake/sundials)
   message(STATUS "SUNDIALS configuration found: ${SUNDIALS_CONFIG}")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Before installing GridKit™ make sure you have all needed dependencies.
 ### Dependencies
 You should have all of the following installed before installing GridKit™
 - A version of
-	- [SUNDIALS](https://github.com/LLNL/sundials) >= 5.5
+	- [SUNDIALS](https://github.com/LLNL/sundials) >= 6.0.0
 	- [Suitesparse](https://github.com/DrTimothyAldenDavis/SuiteSparse) >= 5.x (optional)
 	- [Ipopt](https://github.com/coin-or/Ipopt) >= 3.x (optional)
 - [CMake](https://cmake.org/) >= 3.12

--- a/Solver/Dynamic/Ida.hpp
+++ b/Solver/Dynamic/Ida.hpp
@@ -182,6 +182,7 @@ namespace AnalysisManager
 
         private:
             void* solver_;
+            SUNContext context_;
             SUNMatrix JacobianMat_;
             SUNMatrix JacobianMatB_;
             SUNLinearSolver linearSolver_;

--- a/Solver/SteadyState/Kinsol.hpp
+++ b/Solver/SteadyState/Kinsol.hpp
@@ -185,6 +185,7 @@ namespace AnalysisManager
 
         private:
             void* solver_;
+            SUNContext context_;
             SUNMatrix JacobianMat_;
             SUNLinearSolver linearSolver_;
 


### PR DESCRIPTION
Add SUNDIALS context to `Ida` and `Kinsol` classes. This PR makes GridKit compatible with SUNDIALS >= 6.0, but break backward compatibility with SUNDIALS < 6.